### PR TITLE
Added @XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class) to @XMLEleme…

### DIFF
--- a/src/main/java/edu/iris/dmc/fdsn/station/model/Equipment.java
+++ b/src/main/java/edu/iris/dmc/fdsn/station/model/Equipment.java
@@ -85,7 +85,7 @@ public class Equipment {
 	@XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class)
 	protected ZonedDateTime removalDate;
 	@XmlElement(name = "CalibrationDate")
-	@XmlSchemaType(name = "dateTime")
+	@XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class)
 	protected List<ZonedDateTime> calibrationDate;
 	@XmlAnyElement(lax = true)
 	protected List<Object> any;


### PR DESCRIPTION
…nt(name = "Calibration Date")

Looks like the @XmlJavaTypeAdapter(ZonedDateTimeXmlAdapter.class) was lost during some code changes.  I have replaced it which corrects a failure when trying to load stationXml that has CalibrationDate values in it.